### PR TITLE
Set the response encoding to UTF-8

### DIFF
--- a/src/test/java/org/eclipse/jetty/servlets/EventSourceServletTest.java
+++ b/src/test/java/org/eclipse/jetty/servlets/EventSourceServletTest.java
@@ -93,7 +93,7 @@ public class EventSourceServletTest
 
         // Read and discard the HTTP response
         InputStream input = socket.getInputStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input, "UTF-8"));
         String line = reader.readLine();
         while (line != null)
         {
@@ -107,7 +107,7 @@ public class EventSourceServletTest
         EventSource.Emitter emitter = emitterRef.get();
         Assert.assertNotNull(emitter);
 
-        String data = "foo";
+        String data = "fo\u00F6";
         emitter.data(data);
 
         line = reader.readLine();


### PR DESCRIPTION
The EventSource specification requires that the response is always
utf-8. However the servlet specification requires the default response
encoding to be ISO-8859-1.

Unfortunately ServletOutputStream.println(String) completely ignores
what was passed to ServletResponse.setCharacterEncoding(String). So in
order for the encoding to happen ServletResponse.getWriter() has to be
used.
- set the response encoding to utf-8
- use PrintWriter instead of ServletOutputStream
- add a test for non-latin-1 characters
