### PR TITLE
Add support for Last-Event-ID

### DIFF
--- a/src/main/java/org/eclipse/jetty/servlets/EventSource.java
+++ b/src/main/java/org/eclipse/jetty/servlets/EventSource.java
@@ -38,6 +38,26 @@ public interface EventSource
      * @throws IOException if the implementation of the method throws such exception
      */
     public void onOpen(Emitter emitter) throws IOException;
+    
+    /**
+     * <p>Callback method invoked when an event source connection is resumed
+     * by the client after the client lost the connection to the server.</p>
+     * 
+     * <p>Servers who don't care about the last event id can implement this method in
+     * terms of {@link #onOpen(Emitter)}.
+     * <pre><code>
+     *  public void onResume(Emitter emitter, String lastEventId) throws IOException
+     *  {
+     *      onOpen(emitter);
+     *  }
+     *  </code></pre>
+     *
+     * @see Emitter#id(String)
+     * @param emitter the {@link Emitter} instance that allows to operate on the connection
+     * @param lastEventId the last event id the client received
+     * @throws IOException if the implementation of the method throws such exception
+     */
+    public void onResume(Emitter emitter, String lastEventId) throws IOException;
 
     /**
      * <p>Callback method invoked when an event source connection is closed.</p>
@@ -97,10 +117,25 @@ public interface EventSource
          * @throws IOException if an I/O failure occurred
          */
         public void comment(String comment) throws IOException;
+        
+        /**
+         * <p>Sends an id to the client.</p>
+         * <p>When invoked as: <code>comment("id")</code>, the client will receive the line:</p>
+         * <pre>
+         * id: foo
+         * </pre>
+         * <p>This method has to be invoked before  {@link #data(String)} or {@link #event(String, String)}.</p>
+         *
+         * @see EventSource#onResume(Emitter, String)
+         * @param id the id to send
+         * @throws IOException if an I/O failure occurred
+         */
+        public void id(String id) throws IOException;
 
         /**
          * <p>Closes this event source connection.</p>
          */
         public void close();
     }
+
 }


### PR DESCRIPTION
Adds support for Last-Event-ID. This is two fold. First the, ability to
send an event id to the client is added. Second, a new method is added
that is called with the Last-Event-ID if a connection is resumed.

This implementation has the limitation that the id has to be set before
data or a generic event is sent. This is because these two methods
currently finish a message (CRLF CRLF flush). Two alternatives
would be to either overload these two methods or introduce a dedicated
method that finishes a message. They both seem less attractive.
- Add EventSource#onResume
- Add Emitter#id
