### PR TITLE
Fix code so it works with Firefox.

### DIFF
--- a/src/main/java/org/eclipse/jetty/servlets/EventSourceServlet.java
+++ b/src/main/java/org/eclipse/jetty/servlets/EventSourceServlet.java
@@ -127,7 +127,7 @@ public abstract class EventSourceServlet extends HttpServlet
     protected void respond(HttpServletRequest request, HttpServletResponse response) throws IOException
     {
         response.setStatus(HttpServletResponse.SC_OK);
-        response.setCharacterEncoding(UTF_8.name());
+        response.setCharacterEncoding(null);
         response.setContentType("text/event-stream");
         // By adding this header, and not closing the connection,
         // we disable HTTP chunking, and we can use write()+flush()


### PR DESCRIPTION
The spec only allows "utf-8" or no character encoding. The original code results in "UTF-8" which doesn't work with Firefox. See issue #6.
